### PR TITLE
Improve defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,32 @@ devtools::install_github("lparsons/accucor")
 ```R
 library(accucor)
 
-# Please make sure these parameters are accurate.
-resolution <- 100000  # For Exactive, the Resolution is 100000, defined at Mw 200
-resolution_defined_at <- 200
-
 # Input file (example file included)
+
 carbon_input_file <- system.file("extdata", "C_Sample_Input_Simple.csv", package = "accucor")
 
+
 # Output is written to [input_file]_corrected.xlsx by default
+# Be sure to specify the appropriate resolution.
+# For Exactive, the resolution is 100000, defined at 200 Mw
+
 carbon_corrected <- natural_abundance_correction(
   path = carbon_input_file,
-  resolution = resolution, 
-  resolution_defined_at = resolution_defined_at)
+  resolution = 100000)
+
 
 # The results are also returned as a named list of dataframes for further processing in R
 # "Original", "Corrected", "Normalized", "PoolBeforeDF", "PoolAfterDF"
+
 carbon_corrected
+
+
+# Purity is set to 0.99 for C and N, and 0.98 for H
+# Be sure to specify purity if your samples differ
+carbon_corrected <- natural_abundance_correction(
+  path = carbon_input_file,
+  resolution = 100000,
+  purity = 0.97)
 ```
 
 ## Introduction

--- a/man/natural_abundance_correction.Rd
+++ b/man/natural_abundance_correction.Rd
@@ -6,7 +6,8 @@
 \usage{
 natural_abundance_correction(path, sheet = NULL, compound_database = NULL,
   output_base = NULL, output_filetype = "xlsx", columns_to_skip = NULL,
-  resolution, resolution_defined_at, purity = NULL, report_pool_size = TRUE)
+  resolution, resolution_defined_at = 200, purity = NULL,
+  report_pool_size_before_df = FALSE)
 }
 \arguments{
 \item{path}{Path to xlsx file.}
@@ -28,14 +29,15 @@ output file is written.}
 named 'compound', 'formula', and 'isotopelabel' will be assumed to be
 sample names.}
 
-\item{resolution}{For Exactive, the Resolution is 100000, defined at Mw 200}
+\item{resolution}{For Exactive, the resolution is 100000, defined at Mw 200}
 
-\item{resolution_defined_at}{Resolution defined at (in Mw), e.g. 200 Mw}
+\item{resolution_defined_at}{Mw at which the resolution is defined, default
+200 Mw}
 
 \item{purity}{Isotope purity, default: Carbon 0.99; Deuterium 0.98;
 Nitrogen 0.99}
 
-\item{report_pool_size}{default: TRUE}
+\item{report_pool_size_before_df}{Report PoolSizeBeforeDF, default = FALSE}
 }
 \value{
 Named list of matrices: 'Corrected', 'Normalized',

--- a/tests/testthat/test_natural_abundance_correction.R
+++ b/tests/testthat/test_natural_abundance_correction.R
@@ -3,14 +3,13 @@ library(accucor)
 
 test_that("Carbon correction (Excel, simple format)", {
   resolution <- 100000
-  resolution_defined_at <- 200
   input_file <- system.file("extdata", "C_Sample_Input_Simple.xlsx",
                                    package = "accucor")
 
   corrected <- natural_abundance_correction(
     path = input_file,
     output_base = FALSE,
-    resolution = resolution, resolution_defined_at = resolution_defined_at)
+    resolution = resolution)
 
   read_expected <- function(file, sheet) {
     expected <- readxl::read_excel(path = file, sheet = sheet)
@@ -44,6 +43,54 @@ test_that("Carbon correction (Excel, simple format)", {
                as.data.frame(expected_output$PoolAfterDF))
 })
 
+
+test_that("PoolBeforeDF parameter", {
+  resolution <- 100000
+  input_file <- system.file("extdata", "C_Sample_Input_Simple.xlsx",
+                            package = "accucor")
+
+  corrected <- natural_abundance_correction(
+    path = input_file,
+    output_base = FALSE,
+    report_pool_size_before_df = TRUE,
+    resolution = resolution)
+
+  read_expected <- function(file, sheet) {
+    expected <- readxl::read_excel(path = file, sheet = sheet)
+    expected <- dplyr::mutate_at(expected,
+                                 dplyr::vars(dplyr::ends_with("_Label")),
+                                 as.integer)
+  }
+  expected_output <- list(
+    "Original" = read_expected(
+      system.file("extdata", "C_Sample_Input_Simple.xlsx", package = "accucor"),
+      sheet = 1),
+    "Corrected" = read_expected(
+      system.file("extdata", "C_Sample_Input_Simple_corrected.xlsx", package = "accucor"),
+      sheet = "Corrected"),
+    "Normalized" = read_expected(
+      system.file("extdata", "C_Sample_Input_Simple_corrected.xlsx", package = "accucor"),
+      sheet = "Normalized"),
+    "PoolAfterDF" = read_expected(
+      system.file("extdata", "C_Sample_Input_Simple_corrected.xlsx", package = "accucor"),
+      sheet = "PoolAfterDF"),
+    "PoolBeforeDF" = read_expected(
+      system.file("extdata", "C_Sample_Input_Simple_corrected.xlsx", package = "accucor"),
+      sheet = "PoolBeforeDF")
+  )
+
+  # Must convert to dataframe due to https://github.com/tidyverse/dplyr/issues/2751
+  expect_equal(as.data.frame(corrected$Original),
+               as.data.frame(expected_output$Original))
+  expect_equal(as.data.frame(corrected$Corrected),
+               as.data.frame(expected_output$Corrected))
+  expect_equal(as.data.frame(corrected$Normalized),
+               as.data.frame(expected_output$Normalized))
+  expect_equal(as.data.frame(corrected$PoolAfterDF),
+               as.data.frame(expected_output$PoolAfterDF))
+  expect_equal(as.data.frame(corrected$PoolBeforeDF),
+               as.data.frame(expected_output$PoolBeforeDF))
+})
 
 test_that("Carbon correction (csv, simple format)", {
   resolution <- 100000


### PR DESCRIPTION
No longer require resolution_defined_at (that is stable at 200)
No longer return PoolBeforeDF by default (optional)
Update documentation and README.md to reflect these changes and make the purity option more obvious to users.